### PR TITLE
fix: update Dockerfile to set working directory and correct entrypoin…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM python:alpine3.19
 
 RUN pip install yamlfix 
 
-COPY entrypoint.sh /entrypoint.sh
+WORKDIR /yamlfix-action
 
-ENTRYPOINT ["/entrypoint.sh"]
+COPY entrypoint.sh /yamlfix-action/entrypoint.sh
+
+ENTRYPOINT ["entrypoint.sh"]
 


### PR DESCRIPTION
…t path

- Added `WORKDIR /yamlfix-action` to set the working directory.
- Updated `COPY` command to place `entrypoint.sh` in the working directory.
- Corrected `ENTRYPOINT` to use the relative path `entrypoint.sh`.