### PR TITLE
fix: update yamlfix-action version in workflow

### DIFF
--- a/.github/workflows/yamlfix.yaml
+++ b/.github/workflows/yamlfix.yaml
@@ -31,4 +31,3 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Apply Yamlfix changes
-          file_pattern: '*.yml *.yaml'

--- a/.github/workflows/yamlfix.yaml
+++ b/.github/workflows/yamlfix.yaml
@@ -23,7 +23,7 @@ jobs:
           echo "files=${yaml_files}" >> $GITHUB_OUTPUT
       - name: Yamlfix
         id: yamlfix
-        uses: comfucios/yamlfix-action@v1.0.2
+        uses: comfucios/yamlfix-action@v1.0.3
         with:
           files: ${{ steps.changed_yaml_files.outputs.files }}
       - name: commit-changes

--- a/.github/workflows/yamlfix.yaml
+++ b/.github/workflows/yamlfix.yaml
@@ -22,15 +22,19 @@ jobs:
         run: |
           echo ${{ steps.get_file_changes.outputs.files }} | xargs -n 1 | grep -E "\.yml$|\.yaml$" > changed_files.txt
           yaml_files=$(cat changed_files.txt | tr '\n' ' ')
-          rm changed_files.txt
           echo "files=${yaml_files}" >> $GITHUB_OUTPUT
       - name: Yamlfix
         id: yamlfix
         uses: comfucios/yamlfix-action@v1.0.3
         with:
           files: ${{ steps.changed_yaml_files.outputs.files }}
+      - name: check git
+        run: |
+          git status
+          ls -lah
       - name: commit-changes
         if: ${{ steps.yamlfix.outputs.changed_files == 'true' }}
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Apply Yamlfix changes
+          status_options: --untracked-files=no

--- a/.github/workflows/yamlfix.yaml
+++ b/.github/workflows/yamlfix.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches: [main]
     paths: ['*.yml', '*.yaml']
+permissions:
+  contents: write
 jobs:
   format-yaml-files:
     runs-on: ubuntu-latest
@@ -20,6 +22,7 @@ jobs:
         run: |
           echo ${{ steps.get_file_changes.outputs.files }} | xargs -n 1 | grep -E "\.yml$|\.yaml$" > changed_files.txt
           yaml_files=$(cat changed_files.txt | tr '\n' ' ')
+          rm changed_files.txt
           echo "files=${yaml_files}" >> $GITHUB_OUTPUT
       - name: Yamlfix
         id: yamlfix

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM python:alpine3.19
 
 RUN pip install yamlfix 
 
-WORKDIR /yamlfix-action
-
 COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,8 @@ _output() {
   fi
 }
 
+ls -lah
+
 yamlfix "$@" >/tmp/yamlfix_output 2>&1
 
 if grep -q "0 fixed" /tmp/yamlfix_output; then

--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,1 @@
-hello there
+hello theressss

--- a/test.yaml
+++ b/test.yaml
@@ -1,1 +1,1 @@
-name: "testr"
+name: testr

--- a/test.yaml
+++ b/test.yaml
@@ -1,1 +1,2 @@
-name: "test"
+---
+name: testr

--- a/test.yaml
+++ b/test.yaml
@@ -1,2 +1,1 @@
----
-name: testr
+name: "testr"


### PR DESCRIPTION
- Updated the GitHub Actions workflow to use `comfucios/yamlfix-action@v1.0.3`.
- Modified `test.txt` content for testing purposes.
- Updated `test.yaml` to include YAML front matter and corrected name value.