### PR TITLE
fix: remove file_pattern from git-auto-commit-action in workflow

### DIFF
--- a/.github/workflows/yamlfix.yaml
+++ b/.github/workflows/yamlfix.yaml
@@ -25,7 +25,7 @@ jobs:
           echo "files=${yaml_files}" >> $GITHUB_OUTPUT
       - name: Yamlfix
         id: yamlfix
-        uses: comfucios/yamlfix-action@v1.0.4
+        uses: comfucios/yamlfix-action@v1.0.5
         with:
           files: ${{ steps.changed_yaml_files.outputs.files }}
       - name: check git

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,8 @@ _output() {
 
 ls -lah
 
+git status
+
 yamlfix "$@" >/tmp/yamlfix_output 2>&1
 
 if grep -q "0 fixed" /tmp/yamlfix_output; then

--- a/test.yaml
+++ b/test.yaml
@@ -1,1 +1,1 @@
-name: "testr"
+name: "atestr"


### PR DESCRIPTION
- Removed `file_pattern` parameter from `git-auto-commit-action` to allow committing all changes.
- Added `permissions` to grant write access to contents.
- Removed temporary `changed_files.txt` after processing.
- Updated action version to `v1.0.5` in the workflow.